### PR TITLE
feat(entries): /add_entry speichert content+happiness (fixes #1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,27 @@
+name: "Bug report"
+description: "Problem melden"
+title: "[Bug] <kurzfassung>"
+labels: [bug]
+body:
+  - type: textarea
+    id: beschreibung
+    attributes:
+      label: Beschreibung
+      description: Was ist passiert?
+    validations:
+      required: true
+  - type: textarea
+    id: schritte
+    attributes:
+      label: Schritte zum Reproduzieren
+    validations:
+      required: true
+  - type: input
+    id: erwartung
+    attributes:
+      label: Erwartetes Verhalten
+  - type: textarea
+    id: environment
+    attributes:
+      label: Umgebung
+      description: OS, Browser/Version, App-Version

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: "Feature request"
+description: "Neues Feature vorschlagen"
+title: "[Feat] <kurzfassung>"
+labels: [enhancement]
+body:
+  - type: textarea
+    id: kontext
+    attributes:
+      label: Kontext/Ziel
+      description: Warum ist das Feature wichtig?
+      placeholder: Als <Rolle> möchte ich <Ziel>, um <Nutzen>.
+    validations:
+      required: true
+  - type: textarea
+    id: loesung
+    attributes:
+      label: Lösungsidee
+  - type: textarea
+    id: kriterien
+    attributes:
+      label: Akzeptanzkriterien
+      placeholder: "- [ ] ..."

--- a/.github/ISSUE_TEMPLATE/hz_task.yml
+++ b/.github/ISSUE_TEMPLATE/hz_task.yml
@@ -1,0 +1,19 @@
+name: "HZ-Aufgabe"
+description: "Ticket zu einem Handlungsziel"
+title: "[HZx] <titel>"
+labels: [documentation]
+body:
+  - type: input
+    id: hz
+    attributes:
+      label: Handlungsziel
+      placeholder: HZ1 … HZ7
+  - type: textarea
+    id: aufgabe
+    attributes:
+      label: Aufgabe laut LB
+  - type: textarea
+    id: evidenz
+    attributes:
+      label: Evidenz/Belege
+      placeholder: Links zu PRs, Screenshots, Deployments

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -1,0 +1,37 @@
+name: CI/CD Python Flask
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ dev ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Run tests
+      run: pytest
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    steps:
+    - uses: actions/checkout@v4
+    - name: Deploy to Azure WebApp
+      uses: azure/webapps-deploy@v3
+      with:
+        app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+        publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+        package: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+\# Changelog
+
+
+
+\## \[1.0.0] - 2025-09-21
+
+\### Added
+
+\- Erstes Release der Tagebbbuch-App mit CI/CD-Pipeline und Azure-Deployment.
+
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+\# Beitragen
+
+
+
+\- Branch aus `dev` erstellen: `feature/<titel>`
+
+\- Issue verlinken, PR gegen `dev` → nach Review in `main`
+
+\- Commit-Messages nach Conventional Commits
+
+\- PR-Checkliste beachten
+
+
+

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 23.7.0
+  hooks:
+    - id: black
+      language_version: python3
+
+- repo: https://github.com/pre-commit/mirrors-pylint
+  rev: v3.0.0
+  hooks:
+    - id: pylint
+      args: [--disable=C0114,C0115,C0116]  # ignoriert fehlende Docstrings
+
+- repo: local
+  hooks:
+    - id: pytest
+      name: pytest
+      entry: pytest
+      language: system
+      pass_filenames: false
+      always_run: true
+      stages: [push]


### PR DESCRIPTION
### User Story
Als Benutzer möchte ich beim Erstellen eines Eintrags zusätzlich eine Happiness-Angabe speichern,
damit ich meine Stimmung im Tagebuch nachvollziehen kann.

### Akzeptanzkriterien
- [x] POST `/add_entry` akzeptiert `content` und `happiness`
- [x] Response = 302 Redirect → `/`
- [x] Neues Entry wird in `entries[0]` gespeichert
- [x] Entry.content == "Test Entry Content"
- [x] Entry.happiness == "😃"

### Verknüpftes Issue
fixes #<ISSUE_NR>

### Hinweise
- Tests (`pytest`) laufen lokal grün
- Feature-Branch bleibt bestehen (gemäss LB)
